### PR TITLE
Fix catalog routing

### DIFF
--- a/catalog/urls.py
+++ b/catalog/urls.py
@@ -3,6 +3,8 @@ from . import views
 
 urlpatterns = [
     path('', views.catalog_index, name='catalog_index'),  # ← вот эта строка
-    path('<slug:slug>/', views.category_detail, name='category_detail'),
+    # Маршрут для страницы товара должен располагаться выше,
+    # иначе его "перехватит" маршрут категории
     path('product/<slug:slug>/', views.product_detail, name='product_detail'),
+    path('<slug:slug>/', views.category_detail, name='category_detail'),
 ]


### PR DESCRIPTION
## Summary
- fix product detail route order so it isn't shadowed by category route

## Testing
- `flake8 catalog/urls.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6884d1f2ce1c832096279b464c5f061c