### PR TITLE
Add catalog subcategory pages

### DIFF
--- a/catalog/templates/catalog/funfood.html
+++ b/catalog/templates/catalog/funfood.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+{% block title %}FunFood – Play & Jump{% endblock %}
+{% block content %}
+<h1 class="text-3xl font-bold mb-4 text-center">FunFood</h1>
+<p class="text-center">Diese Seite beschreibt die Kategorie FunFood.</p>
+{% endblock %}

--- a/catalog/templates/catalog/gesellschaftsspiele.html
+++ b/catalog/templates/catalog/gesellschaftsspiele.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+{% block title %}Gesellschaftsspiele – Play & Jump{% endblock %}
+{% block content %}
+<h1 class="text-3xl font-bold mb-4 text-center">Gesellschaftsspiele</h1>
+<p class="text-center">Diese Seite beschreibt die Kategorie Gesellschaftsspiele.</p>
+{% endblock %}

--- a/catalog/templates/catalog/huepfburg.html
+++ b/catalog/templates/catalog/huepfburg.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+{% block title %}Hüpfburg – Play & Jump{% endblock %}
+{% block content %}
+<h1 class="text-3xl font-bold mb-4 text-center">Hüpfburg</h1>
+<p class="text-center">Diese Seite beschreibt die Kategorie Hüpfburg.</p>
+{% endblock %}

--- a/catalog/templates/catalog/index.html
+++ b/catalog/templates/catalog/index.html
@@ -6,25 +6,29 @@
 {% block content %}
 <h1 class="text-3xl font-bold mb-8 text-center">Unser Katalog</h1>
 
-{% if categories %}
-  <div class="grid gap-8 md:grid-cols-3">
-    {% for category in categories %}
-      <div class="bg-white rounded-lg overflow-hidden shadow hover:shadow-lg transition">
-        <a href="{% url 'category_detail' slug=category.slug %}">
-          {% if category.image %}
-            <img class="w-full h-48 object-cover" src="{{ category.image.url }}" alt="{{ category.name }}">
-          {% endif %}
-          <div class="p-4 text-center">
-            <h2 class="text-xl font-semibold mb-2">{{ category.name }}</h2>
-            {% if category.description %}
-              <p class="text-gray-600">{{ category.description }}</p>
-            {% endif %}
-          </div>
-        </a>
-      </div>
-    {% endfor %}
+<div class="flex flex-wrap justify-center gap-8">
+  <div class="w-72 bg-white rounded-lg overflow-hidden shadow hover:shadow-lg transition">
+    <img class="w-full h-48 object-cover" src="https://via.placeholder.com/400x250?text=H%C3%BCpfburg" alt="Hüpfburg">
+    <div class="p-4 text-center">
+      <h2 class="text-xl font-semibold mb-2">Hüpfburg</h2>
+      <a href="{% url 'huepfburg' %}" class="inline-block mt-2 px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600">Mehr erfahren</a>
+    </div>
   </div>
-{% else %}
-  <p>Keine Kategorien verfügbar.</p>
-{% endif %}
+
+  <div class="w-72 bg-white rounded-lg overflow-hidden shadow hover:shadow-lg transition">
+    <img class="w-full h-48 object-cover" src="https://via.placeholder.com/400x250?text=Gesellschaftsspiele" alt="Gesellschaftsspiele">
+    <div class="p-4 text-center">
+      <h2 class="text-xl font-semibold mb-2">Gesellschaftsspiele</h2>
+      <a href="{% url 'gesellschaftsspiele' %}" class="inline-block mt-2 px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600">Mehr erfahren</a>
+    </div>
+  </div>
+
+  <div class="w-72 bg-white rounded-lg overflow-hidden shadow hover:shadow-lg transition">
+    <img class="w-full h-48 object-cover" src="https://via.placeholder.com/400x250?text=FunFood" alt="FunFood">
+    <div class="p-4 text-center">
+      <h2 class="text-xl font-semibold mb-2">FunFood</h2>
+      <a href="{% url 'funfood' %}" class="inline-block mt-2 px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600">Mehr erfahren</a>
+    </div>
+  </div>
+</div>
 {% endblock %}

--- a/catalog/urls.py
+++ b/catalog/urls.py
@@ -2,7 +2,10 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path('', views.catalog_index, name='catalog_index'),  # ← вот эта строка
-    path('<slug:slug>/', views.category_detail, name='category_detail'),
+    path('', views.catalog_index, name='catalog_index'),
+    path('huepfburg/', views.huepfburg, name='huepfburg'),
+    path('gesellschaftsspiele/', views.gesellschaftsspiele, name='gesellschaftsspiele'),
+    path('funfood/', views.funfood, name='funfood'),
     path('product/<slug:slug>/', views.product_detail, name='product_detail'),
+    path('<slug:slug>/', views.category_detail, name='category_detail'),
 ]

--- a/catalog/views.py
+++ b/catalog/views.py
@@ -6,8 +6,19 @@ import json
 
 
 def catalog_index(request):
-    categories = Category.objects.all()
-    return render(request, 'catalog/index.html', {'categories': categories})
+    return render(request, 'catalog/index.html')
+
+
+def huepfburg(request):
+    return render(request, 'catalog/huepfburg.html')
+
+
+def gesellschaftsspiele(request):
+    return render(request, 'catalog/gesellschaftsspiele.html')
+
+
+def funfood(request):
+    return render(request, 'catalog/funfood.html')
 
 
 def category_detail(request, slug):


### PR DESCRIPTION
## Summary
- add subcategory views for the catalog
- link subcategory routes
- redesign catalog index with three cards

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6884eeeeb13c8320967383597d24e88a