### PR TITLE
Show category cards on catalog page

### DIFF
--- a/catalog/templates/catalog/huepfburg.html
+++ b/catalog/templates/catalog/huepfburg.html
@@ -1,6 +1,0 @@
-{% extends "base.html" %}
-{% block title %}Hüpfburg – Play & Jump{% endblock %}
-{% block content %}
-<h1 class="text-3xl font-bold mb-4 text-center">Hüpfburg</h1>
-<p class="text-center">Diese Seite beschreibt die Kategorie Hüpfburg.</p>
-{% endblock %}

--- a/catalog/templates/catalog/huepfburgen.html
+++ b/catalog/templates/catalog/huepfburgen.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+{% block title %}Hüpfburgen – Play & Jump{% endblock %}
+{% block content %}
+<h1 class="text-3xl font-bold mb-4 text-center">Hüpfburgen</h1>
+<p class="text-center">Diese Seite beschreibt die Kategorie Hüpfburgen.</p>
+{% endblock %}

--- a/catalog/templates/catalog/index.html
+++ b/catalog/templates/catalog/index.html
@@ -6,16 +6,16 @@
 {% block content %}
 <h1 class="text-3xl font-bold mb-8 text-center">Unser Katalog</h1>
 
-<div class="flex flex-wrap justify-center gap-8">
-  <div class="w-72 bg-white rounded-lg overflow-hidden shadow hover:shadow-lg transition">
-    <img class="w-full h-48 object-cover" src="https://via.placeholder.com/400x250?text=H%C3%BCpfburg" alt="Hüpfburg">
+<div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+  <div class="bg-white rounded-lg overflow-hidden shadow hover:shadow-lg transition">
+    <img class="w-full h-48 object-cover" src="https://via.placeholder.com/400x250?text=H%C3%BCpfburgen" alt="Hüpfburgen">
     <div class="p-4 text-center">
-      <h2 class="text-xl font-semibold mb-2">Hüpfburg</h2>
-      <a href="{% url 'huepfburg' %}" class="inline-block mt-2 px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600">Mehr erfahren</a>
+      <h2 class="text-xl font-semibold mb-2">Hüpfburgen</h2>
+      <a href="{% url 'huepfburgen' %}" class="inline-block mt-2 px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600">Mehr erfahren</a>
     </div>
   </div>
 
-  <div class="w-72 bg-white rounded-lg overflow-hidden shadow hover:shadow-lg transition">
+  <div class="bg-white rounded-lg overflow-hidden shadow hover:shadow-lg transition">
     <img class="w-full h-48 object-cover" src="https://via.placeholder.com/400x250?text=Gesellschaftsspiele" alt="Gesellschaftsspiele">
     <div class="p-4 text-center">
       <h2 class="text-xl font-semibold mb-2">Gesellschaftsspiele</h2>
@@ -23,7 +23,7 @@
     </div>
   </div>
 
-  <div class="w-72 bg-white rounded-lg overflow-hidden shadow hover:shadow-lg transition">
+  <div class="bg-white rounded-lg overflow-hidden shadow hover:shadow-lg transition">
     <img class="w-full h-48 object-cover" src="https://via.placeholder.com/400x250?text=FunFood" alt="FunFood">
     <div class="p-4 text-center">
       <h2 class="text-xl font-semibold mb-2">FunFood</h2>

--- a/catalog/urls.py
+++ b/catalog/urls.py
@@ -3,7 +3,7 @@ from . import views
 
 urlpatterns = [
     path('', views.catalog_index, name='catalog_index'),
-    path('huepfburg/', views.huepfburg, name='huepfburg'),
+    path('huepfburgen/', views.huepfburgen, name='huepfburgen'),
     path('gesellschaftsspiele/', views.gesellschaftsspiele, name='gesellschaftsspiele'),
     path('funfood/', views.funfood, name='funfood'),
     path('product/<slug:slug>/', views.product_detail, name='product_detail'),

--- a/catalog/views.py
+++ b/catalog/views.py
@@ -9,8 +9,9 @@ def catalog_index(request):
     return render(request, 'catalog/index.html')
 
 
-def huepfburg(request):
-    return render(request, 'catalog/huepfburg.html')
+def huepfburgen(request):
+    """Display information about the Hüpfburgen category."""
+    return render(request, 'catalog/huepfburgen.html')
 
 
 def gesellschaftsspiele(request):

--- a/main/templates/partials/navbar.html
+++ b/main/templates/partials/navbar.html
@@ -2,7 +2,7 @@
     <div class="relative inline-block group">
         <a class="hover:text-cyan-200" href="/katalog/">Katalog</a>
         <div class="absolute left-0 hidden group-hover:block bg-gray-800 text-white mt-1 rounded shadow-lg">
-            <a class="block px-4 py-2 hover:bg-gray-700" href="/katalog/huepfburg/">Hüpfburg</a>
+            <a class="block px-4 py-2 hover:bg-gray-700" href="/katalog/huepfburgen/">Hüpfburgen</a>
             <a class="block px-4 py-2 hover:bg-gray-700" href="/katalog/gesellschaftsspiele/">Gesellschaftsspiele</a>
             <a class="block px-4 py-2 hover:bg-gray-700" href="/katalog/funfood/">FunFood</a>
         </div>


### PR DESCRIPTION
## Summary
- link "Hüpfburgen" page via new route `/katalog/huepfburgen/`
- show cards for each category on catalog index page
- update navbar dropdown links

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6884f27b1bf08320be7d34165c3401da