### PR TITLE
Add /katalog/ page with category listing

### DIFF
--- a/main/templates/main/katalog.html
+++ b/main/templates/main/katalog.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% block title %}Каталог – Play & Jump{% endblock %}
+
+{% block content %}
+<h1 class="text-2xl font-semibold mb-4">Каталог</h1>
+<div class="grid gap-6 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+  {% for category in categories %}
+  <div class="bg-white border border-gray-300 rounded-lg p-4 text-center transition hover:-translate-y-1 hover:shadow">
+    <a href="{% url 'category_detail' slug=category.slug %}">
+      {% if category.image %}
+      <img class="mb-2 mx-auto" src="{{ category.image.url }}" alt="{{ category.name }}">
+      {% endif %}
+      <h2 class="font-medium">{{ category.name }}</h2>
+    </a>
+  </div>
+  {% empty %}
+  <p>Категории отсутствуют.</p>
+  {% endfor %}
+</div>
+{% endblock %}

--- a/main/templates/partials/navbar.html
+++ b/main/templates/partials/navbar.html
@@ -1,5 +1,5 @@
 <nav class="space-x-4">
-    <a class="hover:text-cyan-200" href="/katalog/">Katalog</a>
+    <a class="hover:text-cyan-200" href="{% url 'katalog' %}">Katalog</a>
     <a class="hover:text-cyan-200" href="/ueber-uns/">Über uns</a>
     <a class="hover:text-cyan-200" href="/kontakt/">Kontakt</a>
 </nav>

--- a/main/urls.py
+++ b/main/urls.py
@@ -8,5 +8,6 @@ urlpatterns = [
     path('impressum/', views.impressum, name='impressum'),
     path('datenschutz/', views.datenschutz, name='datenschutz'),
     path('ueber-uns/', views.ueber_uns, name='ueber_uns'),
+    path('katalog/', views.katalog_view, name='katalog'),
     path('<slug:slug>/', views.page_detail, name='page_detail'),
 ]

--- a/main/views.py
+++ b/main/views.py
@@ -1,6 +1,6 @@
 from django.shortcuts import render, get_object_or_404
 from django.http import Http404
-from catalog.models import Product
+from catalog.models import Product, Category
 from .models import Page
 
 def home(request):
@@ -21,6 +21,11 @@ def datenschutz(request):
 
 def ueber_uns(request):
     return render(request, 'pages/ueber_uns.html')
+
+def katalog_view(request):
+    categories = Category.objects.all()
+    return render(request, 'main/katalog.html', {'categories': categories})
+
 def page_detail(request, slug):
     page = get_object_or_404(Page, slug=slug, is_active=True)
     return render(request, 'main/page_detail.html', {'page': page})


### PR DESCRIPTION
## Summary
- expose `/katalog/` URL before the slug catch-all
- implement `katalog_view` to list categories
- add template for displaying all categories
- link navbar "Katalog" item to the new named route

## Testing
- `python manage.py check`
- `python manage.py makemigrations --check`
- `python manage.py migrate --plan`


------
https://chatgpt.com/codex/tasks/task_e_6884fdb4a2408320a5842414989dc5fc